### PR TITLE
feat: disable redundant api requests

### DIFF
--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -858,35 +858,36 @@ export const deleteChatById = async (token: string, id: string) => {
 };
 
 export const getTagsById = async (token: string, id: string) => {
-	let error = null;
+	return []
+	// let error = null;
 
-	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${id}/tags`, {
-		method: 'GET',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			...(token && { authorization: `Bearer ${token}` })
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.then((json) => {
-			return json;
-		})
-		.catch((err) => {
-			error = err;
+	// const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${id}/tags`, {
+	// 	method: 'GET',
+	// 	headers: {
+	// 		Accept: 'application/json',
+	// 		'Content-Type': 'application/json',
+	// 		...(token && { authorization: `Bearer ${token}` })
+	// 	}
+	// })
+	// 	.then(async (res) => {
+	// 		if (!res.ok) throw await res.json();
+	// 		return res.json();
+	// 	})
+	// 	.then((json) => {
+	// 		return json;
+	// 	})
+	// 	.catch((err) => {
+	// 		error = err;
 
-			console.log(err);
-			return null;
-		});
+	// 		console.log(err);
+	// 		return null;
+	// 	});
 
-	if (error) {
-		throw error;
-	}
+	// if (error) {
+	// 	throw error;
+	// }
 
-	return res;
+	// return res;
 };
 
 export const addTagById = async (token: string, id: string, tagName: string) => {

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -858,7 +858,7 @@ export const deleteChatById = async (token: string, id: string) => {
 };
 
 export const getTagsById = async (token: string, id: string) => {
-	return []
+	return [];
 	// let error = null;
 
 	// const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${id}/tags`, {

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -339,34 +339,37 @@ export const getAllUserChats = async (token: string) => {
 };
 
 export const getAllTags = async (token: string) => {
-	let error = null;
+	// Always return empty array regardless of API response
+	return [];
 
-	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/all/tags`, {
-		method: 'GET',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			...(token && { authorization: `Bearer ${token}` })
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.then((json) => {
-			return json;
-		})
-		.catch((err) => {
-			error = err;
-			console.log(err);
-			return null;
-		});
+	// let error = null;
 
-	if (error) {
-		throw error;
-	}
+	// const res = await fetch(`${WEBUI_API_BASE_URL}/chats/all/tags`, {
+	// 	method: 'GET',
+	// 	headers: {
+	// 		Accept: 'application/json',
+	// 		'Content-Type': 'application/json',
+	// 		...(token && { authorization: `Bearer ${token}` })
+	// 	}
+	// })
+	// 	.then(async (res) => {
+	// 		if (!res.ok) throw await res.json();
+	// 		return res.json();
+	// 	})
+	// 	.then((json) => {
+	// 		return json;
+	// 	})
+	// 	.catch((err) => {
+	// 		error = err;
+	// 		console.log(err);
+	// 		return null;
+	// 	});
 
-	return res;
+	// if (error) {
+	// 	throw error;
+	// }
+
+	// return res;
 };
 
 export const getPinnedChatList = async (token: string = '') => {

--- a/src/lib/apis/ollama/index.ts
+++ b/src/lib/apis/ollama/index.ts
@@ -176,35 +176,36 @@ export const updateOllamaUrls = async (token: string = '', urls: string[]) => {
 };
 
 export const getOllamaVersion = async (token: string, urlIdx?: number) => {
-	let error = null;
+	return ''
+	// let error = null;
 
-	const res = await fetch(`${OLLAMA_API_BASE_URL}/api/version${urlIdx ? `/${urlIdx}` : ''}`, {
-		method: 'GET',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			...(token && { authorization: `Bearer ${token}` })
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.catch((err) => {
-			console.log(err);
-			if ('detail' in err) {
-				error = err.detail;
-			} else {
-				error = 'Server connection failed';
-			}
-			return null;
-		});
+	// const res = await fetch(`${OLLAMA_API_BASE_URL}/api/version${urlIdx ? `/${urlIdx}` : ''}`, {
+	// 	method: 'GET',
+	// 	headers: {
+	// 		Accept: 'application/json',
+	// 		'Content-Type': 'application/json',
+	// 		...(token && { authorization: `Bearer ${token}` })
+	// 	}
+	// })
+	// 	.then(async (res) => {
+	// 		if (!res.ok) throw await res.json();
+	// 		return res.json();
+	// 	})
+	// 	.catch((err) => {
+	// 		console.log(err);
+	// 		if ('detail' in err) {
+	// 			error = err.detail;
+	// 		} else {
+	// 			error = 'Server connection failed';
+	// 		}
+	// 		return null;
+	// 	});
 
-	if (error) {
-		throw error;
-	}
+	// if (error) {
+	// 	throw error;
+	// }
 
-	return res?.version ?? false;
+	// return res?.version ?? false;
 };
 
 export const getOllamaModels = async (token: string = '', urlIdx: null | number = null) => {

--- a/src/lib/apis/ollama/index.ts
+++ b/src/lib/apis/ollama/index.ts
@@ -176,7 +176,7 @@ export const updateOllamaUrls = async (token: string = '', urls: string[]) => {
 };
 
 export const getOllamaVersion = async (token: string, urlIdx?: number) => {
-	return ''
+	return '';
 	// let error = null;
 
 	// const res = await fetch(`${OLLAMA_API_BASE_URL}/api/version${urlIdx ? `/${urlIdx}` : ''}`, {


### PR DESCRIPTION
disabled the following redundant apis requests



1. api/v1/chats/88b7377b-e632-4476-ad95-53d4f6d8a0e1/tags 
2. /ollama/api/version 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Chat tag retrieval disabled; chats will no longer display or return tags.
  - External version check disabled; the version field will be blank or hidden.
  - No user settings or data are changed; core workflows remain functional but tag-based filters and the version indicator won’t populate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->