### PR TITLE
fix: insert new chat error

### DIFF
--- a/backend/open_webui/utils/chat_encryption_proxy.py
+++ b/backend/open_webui/utils/chat_encryption_proxy.py
@@ -121,7 +121,6 @@ class ChatTableEncryptionProxy(ChatTable):
                 chat_record = Chat(
                     id=id,
                     user_id=user_id,
-                    folder_id=form_data.folder_id,
                     created_at=int(time.time()),
                     updated_at=int(time.time()),
                 )


### PR DESCRIPTION
#### Issue

I have seen the below logs in the Private Chat CVM, which seems to be a bug in the implementation. 

```
ERROR    | open_webui.utils.chat_encryption_proxy:insert_new_chat:153 - Error in encrypted insert_new_chat: 'ChatForm' object has no attribute 'folder_id' - {}
```

The `folder_id` attribute only exists in `chat_form.chat` and is not available in `chat_form`, which fails every `/chat/new` call. 

#### Complete Logs

```log
2025-08-27T13:34:26.125761817Z 2025-08-27 13:34:26.123 | ERROR    | open_webui.utils.chat_encryption_proxy:insert_new_chat:153 - Error in encrypted insert_new_chat: 'ChatForm' object has no attribute 'folder_id' - {}
2025-08-27T13:34:26.262277228Z 2025-08-27 13:34:26.260 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 10.4.0.1:0 - "POST /api/v1/chats/new HTTP/1.0" 200 - {}
2025-08-27T13:34:26.434364747Z 2025-08-27 13:34:26.432 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 10.4.0.1:0 - "GET /api/v1/chats/?page=2 HTTP/1.0" 200 - {}
2025-08-27T13:34:26.485904734Z 2025-08-27 13:34:26.484 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 10.4.0.1:0 - "GET /static/favicon.png HTTP/1.0" 304 - {}
2025-08-27T13:34:26.710105222Z 2025-08-27 13:34:26.708 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 10.4.0.1:0 - "POST /api/v1/chats/b19e6999-ed68-4752-931b-cbca9d61cd9e HTTP/1.0" 200 - {}
2025-08-27T13:34:26.868710009Z 2025-08-27 13:34:26.866 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 10.4.0.1:0 - "GET /api/v1/chats/?page=1 HTTP/1.0" 200 - {}
2025-08-27T13:34:27.357570450Z 2025-08-27 13:34:27.355 | INFO     | open_webui.routers.openai:get_all_models:389 - get_all_models() - {}
2025-08-27T13:34:29.902828694Z 2025-08-27 13:34:29.901 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 10.4.0.1:0 - "POST /api/chat/completions HTTP/1.0" 200 - {}
2025-08-27T13:34:30.087131309Z 2025-08-27 13:34:30.086 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 10.4.0.1:0 - "GET /api/v1/chats/?page=1 HTTP/1.0" 200 - {}
2025-08-27T13:34:44.255695207Z 2025-08-27 13:34:44.253 | INFO     | open_webui.routers.openai:get_all_models:389 - get_all_models() - {}
2025-08-27T13:34:44.591199310Z 2025-08-27 13:34:44.589 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 10.4.0.1:0 - "POST /api/chat/completed HTTP/1.0" 200 - {}
2025-08-27T13:34:44.893762244Z 2025-08-27 13:34:44.891 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 10.4.0.1:0 - "POST /api/v1/chats/b19e6999-ed68-4752-931b-cbca9d61cd9e HTTP/1.0" 200 - {}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - New chats are now created without being automatically assigned to a folder.
  - Users can manually move or assign chats to folders after creation.
  - Existing chats and their folder assignments remain unchanged.
  - Folder filters will not auto-include newly created chats until assigned.
  - No changes to chat encryption or storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->