### PR TITLE
feat: disable chat control and refine settings menu

### DIFF
--- a/src/lib/components/chat/Artifacts.svelte
+++ b/src/lib/components/chat/Artifacts.svelte
@@ -189,14 +189,14 @@
 			<div
 				class="pointer-events-auto z-20 flex justify-between items-center p-2.5 font-primar text-gray-900 dark:text-white"
 			>
-				<button
+				<!-- <button
 					class="self-center pointer-events-auto p-1 rounded-full bg-white dark:bg-gray-850"
 					on:click={() => {
 						showArtifacts.set(false);
 					}}
 				>
 					<ArrowLeft className="size-3.5  text-gray-900 dark:text-white" />
-				</button>
+				</button> -->
 
 				<div class="flex-1 flex items-center justify-between">
 					<div class="flex items-center space-x-2">

--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -121,7 +121,7 @@
 						</Menu>
 					{/if}
 
-					<Tooltip content={$i18n.t('Controls')}>
+					<!-- <Tooltip content={$i18n.t('Controls')}>
 						<button
 							class=" flex cursor-pointer px-2 py-2 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-850 transition"
 							on:click={async () => {
@@ -133,7 +133,7 @@
 								<AdjustmentsHorizontal className=" size-5" strokeWidth="0.5" />
 							</div>
 						</button>
-					</Tooltip>
+					</Tooltip> -->
 
 					<Tooltip content={$i18n.t('New Chat')}>
 						<button

--- a/src/lib/components/chat/Overview.svelte
+++ b/src/lib/components/chat/Overview.svelte
@@ -162,14 +162,14 @@
 <div class="w-full h-full relative">
 	<div class=" absolute z-50 w-full flex justify-between dark:text-gray-100 px-4 py-3.5">
 		<div class="flex items-center gap-2.5">
-			<button
+			<!-- <button
 				class="self-center p-0.5"
 				on:click={() => {
 					showOverview.set(false);
 				}}
 			>
 				<ArrowLeft className="size-3.5" />
-			</button>
+			</button> -->
 			<div class=" text-lg font-medium self-center font-primary">{$i18n.t('Chat Overview')}</div>
 		</div>
 		<button

--- a/src/lib/components/chat/Overview.svelte
+++ b/src/lib/components/chat/Overview.svelte
@@ -189,7 +189,7 @@
 			{nodeTypes}
 			{edges}
 			on:nodeclick={(e) => {
-				console.log(e.detail.node.data);
+				// console.log(e.detail.node.data);
 				dispatch('nodeclick', e.detail);
 				selectedMessageId = e.detail.node.data.message.id;
 				fitView({ nodes: [{ id: selectedMessageId }] });

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -53,101 +53,101 @@
 				'systemparameters'
 			]
 		},
-		{
-			id: 'interface',
-			title: 'Interface',
-			keywords: [
-				'defaultmodel',
-				'selectmodel',
-				'ui',
-				'userinterface',
-				'display',
-				'layout',
-				'design',
-				'landingpage',
-				'landingpagemode',
-				'default',
-				'chat',
-				'chatbubble',
-				'chatui',
-				'username',
-				'showusername',
-				'displayusername',
-				'widescreen',
-				'widescreenmode',
-				'fullscreen',
-				'expandmode',
-				'chatdirection',
-				'lefttoright',
-				'ltr',
-				'righttoleft',
-				'rtl',
-				'notifications',
-				'toast',
-				'toastnotifications',
-				'largechunks',
-				'streamlargechunks',
-				'scroll',
-				'scrollonbranchchange',
-				'scrollbehavior',
-				'richtext',
-				'richtextinput',
-				'background',
-				'chatbackground',
-				'chatbackgroundimage',
-				'backgroundimage',
-				'uploadbackground',
-				'resetbackground',
-				'titleautogen',
-				'titleautogeneration',
-				'autotitle',
-				'chattags',
-				'autochattags',
-				'responseautocopy',
-				'clipboard',
-				'location',
-				'userlocation',
-				'userlocationaccess',
-				'haptic',
-				'hapticfeedback',
-				'vibration',
-				'voice',
-				'voicecontrol',
-				'voiceinterruption',
-				'call',
-				'emojis',
-				'displayemoji',
-				'save',
-				'interfaceoptions',
-				'interfacecustomization',
-				'alwaysonwebsearch'
-			]
-		},
-		{
-			id: 'connections',
-			title: 'Connections',
-			keywords: []
-		},
-		{
-			id: 'tools',
-			title: 'Tools',
-			keywords: []
-		},
-		{
-			id: 'personalization',
-			title: 'Personalization',
-			keywords: [
-				'personalization',
-				'memory',
-				'personalize',
-				'preferences',
-				'profile',
-				'personalsettings',
-				'customsettings',
-				'userpreferences',
-				'accountpreferences'
-			]
-		},
+		// {
+		// 	id: 'interface',
+		// 	title: 'Interface',
+		// 	keywords: [
+		// 		'defaultmodel',
+		// 		'selectmodel',
+		// 		'ui',
+		// 		'userinterface',
+		// 		'display',
+		// 		'layout',
+		// 		'design',
+		// 		'landingpage',
+		// 		'landingpagemode',
+		// 		'default',
+		// 		'chat',
+		// 		'chatbubble',
+		// 		'chatui',
+		// 		'username',
+		// 		'showusername',
+		// 		'displayusername',
+		// 		'widescreen',
+		// 		'widescreenmode',
+		// 		'fullscreen',
+		// 		'expandmode',
+		// 		'chatdirection',
+		// 		'lefttoright',
+		// 		'ltr',
+		// 		'righttoleft',
+		// 		'rtl',
+		// 		'notifications',
+		// 		'toast',
+		// 		'toastnotifications',
+		// 		'largechunks',
+		// 		'streamlargechunks',
+		// 		'scroll',
+		// 		'scrollonbranchchange',
+		// 		'scrollbehavior',
+		// 		'richtext',
+		// 		'richtextinput',
+		// 		'background',
+		// 		'chatbackground',
+		// 		'chatbackgroundimage',
+		// 		'backgroundimage',
+		// 		'uploadbackground',
+		// 		'resetbackground',
+		// 		'titleautogen',
+		// 		'titleautogeneration',
+		// 		'autotitle',
+		// 		'chattags',
+		// 		'autochattags',
+		// 		'responseautocopy',
+		// 		'clipboard',
+		// 		'location',
+		// 		'userlocation',
+		// 		'userlocationaccess',
+		// 		'haptic',
+		// 		'hapticfeedback',
+		// 		'vibration',
+		// 		'voice',
+		// 		'voicecontrol',
+		// 		'voiceinterruption',
+		// 		'call',
+		// 		'emojis',
+		// 		'displayemoji',
+		// 		'save',
+		// 		'interfaceoptions',
+		// 		'interfacecustomization',
+		// 		'alwaysonwebsearch'
+		// 	]
+		// },
+		// {
+		// 	id: 'connections',
+		// 	title: 'Connections',
+		// 	keywords: []
+		// },
+		// {
+		// 	id: 'tools',
+		// 	title: 'Tools',
+		// 	keywords: []
+		// },
+		// {
+		// 	id: 'personalization',
+		// 	title: 'Personalization',
+		// 	keywords: [
+		// 		'personalization',
+		// 		'memory',
+		// 		'personalize',
+		// 		'preferences',
+		// 		'profile',
+		// 		'personalsettings',
+		// 		'customsettings',
+		// 		'userpreferences',
+		// 		'accountpreferences'
+		// 	]
+		// },
 		// {
 		// 	id: 'audio',
 		// 	title: 'Audio',
@@ -193,78 +193,78 @@
 		// 		'voicemodes'
 		// 	]
 		// },
-		{
-			id: 'chats',
-			title: 'Chats',
-			keywords: [
-				'chat',
-				'messages',
-				'conversations',
-				'chatsettings',
-				'history',
-				'chathistory',
-				'messagehistory',
-				'messagearchive',
-				'convo',
-				'chats',
-				'conversationhistory',
-				'exportmessages',
-				'chatactivity'
-			]
-		},
-		{
-			id: 'account',
-			title: 'Account',
-			keywords: [
-				'account',
-				'profile',
-				'security',
-				'privacy',
-				'settings',
-				'login',
-				'useraccount',
-				'userdata',
-				'api',
-				'apikey',
-				'userprofile',
-				'profiledetails',
-				'accountsettings',
-				'accountpreferences',
-				'securitysettings',
-				'privacysettings'
-			]
-		},
-		{
-			id: 'admin',
-			title: 'Admin',
-			keywords: [
-				'admin',
-				'administrator',
-				'adminsettings',
-				'adminpanel',
-				'systemadmin',
-				'administratoraccess',
-				'systemcontrol',
-				'manage',
-				'management',
-				'admincontrols',
-				'adminfeatures',
-				'usercontrol',
-				'arenamodel',
-				'evaluations',
-				'websearch',
-				'database',
-				'pipelines',
-				'images',
-				'audio',
-				'documents',
-				'rag',
-				'models',
-				'ollama',
-				'openai',
-				'users'
-			]
-		},
+		// {
+		// 	id: 'chats',
+		// 	title: 'Chats',
+		// 	keywords: [
+		// 		'chat',
+		// 		'messages',
+		// 		'conversations',
+		// 		'chatsettings',
+		// 		'history',
+		// 		'chathistory',
+		// 		'messagehistory',
+		// 		'messagearchive',
+		// 		'convo',
+		// 		'chats',
+		// 		'conversationhistory',
+		// 		'exportmessages',
+		// 		'chatactivity'
+		// 	]
+		// },
+		// {
+		// 	id: 'account',
+		// 	title: 'Account',
+		// 	keywords: [
+		// 		'account',
+		// 		'profile',
+		// 		'security',
+		// 		'privacy',
+		// 		'settings',
+		// 		'login',
+		// 		'useraccount',
+		// 		'userdata',
+		// 		'api',
+		// 		'apikey',
+		// 		'userprofile',
+		// 		'profiledetails',
+		// 		'accountsettings',
+		// 		'accountpreferences',
+		// 		'securitysettings',
+		// 		'privacysettings'
+		// 	]
+		// },
+		// {
+		// 	id: 'admin',
+		// 	title: 'Admin',
+		// 	keywords: [
+		// 		'admin',
+		// 		'administrator',
+		// 		'adminsettings',
+		// 		'adminpanel',
+		// 		'systemadmin',
+		// 		'administratoraccess',
+		// 		'systemcontrol',
+		// 		'manage',
+		// 		'management',
+		// 		'admincontrols',
+		// 		'adminfeatures',
+		// 		'usercontrol',
+		// 		'arenamodel',
+		// 		'evaluations',
+		// 		'websearch',
+		// 		'database',
+		// 		'pipelines',
+		// 		'images',
+		// 		'audio',
+		// 		'documents',
+		// 		'rag',
+		// 		'models',
+		// 		'ollama',
+		// 		'openai',
+		// 		'users'
+		// 	]
+		// },
 		{
 			id: 'about',
 			title: 'About',
@@ -395,7 +395,7 @@
 				id="settings-tabs-container"
 				class="tabs flex flex-row overflow-x-auto gap-2.5 md:gap-1 md:flex-col flex-1 md:flex-none md:w-40 dark:text-gray-200 text-sm font-medium text-left mb-1 md:mb-0 -translate-y-1"
 			>
-				<div class="hidden md:flex w-full rounded-xl -mb-1 px-0.5 gap-2" id="settings-search">
+				<!-- <div class="hidden md:flex w-full rounded-xl -mb-1 px-0.5 gap-2" id="settings-search">
 					<div class="self-center rounded-l-xl bg-transparent">
 						<Search className="size-3.5" />
 					</div>
@@ -405,7 +405,7 @@
 						on:input={searchDebounceHandler}
 						placeholder={$i18n.t('Search')}
 					/>
-				</div>
+				</div> -->
 
 				{#if visibleTabs.length > 0}
 					{#each visibleTabs as tabId (tabId)}

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -23,8 +23,6 @@
 
 	export let show = false;
 
-	const isAdminRole = $user?.role === 'admin';
-
 	interface SettingsTab {
 		id: string;
 		title: string;
@@ -126,19 +124,19 @@
 				'interfacecustomization',
 				'alwaysonwebsearch'
 			],
-			display: isAdminRole
+			display: false
 		},
 		{
 			id: 'connections',
 			title: 'Connections',
 			keywords: [],
-			display: isAdminRole
+			display: false
 		},
 		{
 			id: 'tools',
 			title: 'Tools',
 			keywords: [],
-			display: isAdminRole
+			display: false
 		},
 		{
 			id: 'personalization',
@@ -154,53 +152,54 @@
 				'userpreferences',
 				'accountpreferences'
 			],
-			display: isAdminRole
+			display: false
 		},
-		// {
-		// 	id: 'audio',
-		// 	title: 'Audio',
-		// 	keywords: [
-		// 		'audio',
-		// 		'sound',
-		// 		'soundsettings',
-		// 		'audiocontrol',
-		// 		'volume',
-		// 		'speech',
-		// 		'speechrecognition',
-		// 		'stt',
-		// 		'speechtotext',
-		// 		'tts',
-		// 		'texttospeech',
-		// 		'playback',
-		// 		'playbackspeed',
-		// 		'voiceplayback',
-		// 		'speechplayback',
-		// 		'audiooutput',
-		// 		'speechengine',
-		// 		'voicecontrol',
-		// 		'audioplayback',
-		// 		'transcription',
-		// 		'autotranscribe',
-		// 		'autosend',
-		// 		'speechsettings',
-		// 		'audiovoice',
-		// 		'voiceoptions',
-		// 		'setvoice',
-		// 		'nonlocalvoices',
-		// 		'savesettings',
-		// 		'audioconfig',
-		// 		'speechconfig',
-		// 		'voicerecognition',
-		// 		'speechsynthesis',
-		// 		'speechmode',
-		// 		'voicespeed',
-		// 		'speechrate',
-		// 		'speechspeed',
-		// 		'audioinput',
-		// 		'audiofeatures',
-		// 		'voicemodes'
-		// 	]
-		// },
+		{
+			id: 'audio',
+			title: 'Audio',
+			keywords: [
+				'audio',
+				'sound',
+				'soundsettings',
+				'audiocontrol',
+				'volume',
+				'speech',
+				'speechrecognition',
+				'stt',
+				'speechtotext',
+				'tts',
+				'texttospeech',
+				'playback',
+				'playbackspeed',
+				'voiceplayback',
+				'speechplayback',
+				'audiooutput',
+				'speechengine',
+				'voicecontrol',
+				'audioplayback',
+				'transcription',
+				'autotranscribe',
+				'autosend',
+				'speechsettings',
+				'audiovoice',
+				'voiceoptions',
+				'setvoice',
+				'nonlocalvoices',
+				'savesettings',
+				'audioconfig',
+				'speechconfig',
+				'voicerecognition',
+				'speechsynthesis',
+				'speechmode',
+				'voicespeed',
+				'speechrate',
+				'speechspeed',
+				'audioinput',
+				'audiofeatures',
+				'voicemodes'
+			],
+			display: false
+		},
 		{
 			id: 'chats',
 			title: 'Chats',
@@ -219,7 +218,7 @@
 				'exportmessages',
 				'chatactivity'
 			],
-			display: isAdminRole
+			display: false
 		},
 		{
 			id: 'account',
@@ -242,7 +241,7 @@
 				'securitysettings',
 				'privacysettings'
 			],
-			display: isAdminRole
+			display: false
 		},
 		{
 			id: 'admin',
@@ -274,7 +273,7 @@
 				'openai',
 				'users'
 			],
-			display: isAdminRole
+			display: false
 		},
 		{
 			id: 'about',

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -23,10 +23,13 @@
 
 	export let show = false;
 
+	const isAdminRole = $user?.role === 'admin';
+
 	interface SettingsTab {
 		id: string;
 		title: string;
 		keywords: string[];
+		display: boolean;
 	}
 
 	const searchData: SettingsTab[] = [
@@ -51,103 +54,108 @@
 				'languageoptions',
 				'defaultparameters',
 				'systemparameters'
-			]
+			],
+			display: true
 		},
-		// {
-		// 	id: 'interface',
-		// 	title: 'Interface',
-		// 	keywords: [
-		// 		'defaultmodel',
-		// 		'selectmodel',
-		// 		'ui',
-		// 		'userinterface',
-		// 		'display',
-		// 		'layout',
-		// 		'design',
-		// 		'landingpage',
-		// 		'landingpagemode',
-		// 		'default',
-		// 		'chat',
-		// 		'chatbubble',
-		// 		'chatui',
-		// 		'username',
-		// 		'showusername',
-		// 		'displayusername',
-		// 		'widescreen',
-		// 		'widescreenmode',
-		// 		'fullscreen',
-		// 		'expandmode',
-		// 		'chatdirection',
-		// 		'lefttoright',
-		// 		'ltr',
-		// 		'righttoleft',
-		// 		'rtl',
-		// 		'notifications',
-		// 		'toast',
-		// 		'toastnotifications',
-		// 		'largechunks',
-		// 		'streamlargechunks',
-		// 		'scroll',
-		// 		'scrollonbranchchange',
-		// 		'scrollbehavior',
-		// 		'richtext',
-		// 		'richtextinput',
-		// 		'background',
-		// 		'chatbackground',
-		// 		'chatbackgroundimage',
-		// 		'backgroundimage',
-		// 		'uploadbackground',
-		// 		'resetbackground',
-		// 		'titleautogen',
-		// 		'titleautogeneration',
-		// 		'autotitle',
-		// 		'chattags',
-		// 		'autochattags',
-		// 		'responseautocopy',
-		// 		'clipboard',
-		// 		'location',
-		// 		'userlocation',
-		// 		'userlocationaccess',
-		// 		'haptic',
-		// 		'hapticfeedback',
-		// 		'vibration',
-		// 		'voice',
-		// 		'voicecontrol',
-		// 		'voiceinterruption',
-		// 		'call',
-		// 		'emojis',
-		// 		'displayemoji',
-		// 		'save',
-		// 		'interfaceoptions',
-		// 		'interfacecustomization',
-		// 		'alwaysonwebsearch'
-		// 	]
-		// },
-		// {
-		// 	id: 'connections',
-		// 	title: 'Connections',
-		// 	keywords: []
-		// },
-		// {
-		// 	id: 'tools',
-		// 	title: 'Tools',
-		// 	keywords: []
-		// },
-		// {
-		// 	id: 'personalization',
-		// 	title: 'Personalization',
-		// 	keywords: [
-		// 		'personalization',
-		// 		'memory',
-		// 		'personalize',
-		// 		'preferences',
-		// 		'profile',
-		// 		'personalsettings',
-		// 		'customsettings',
-		// 		'userpreferences',
-		// 		'accountpreferences'
-		// 	]
-		// },
+		{
+			id: 'interface',
+			title: 'Interface',
+			keywords: [
+				'defaultmodel',
+				'selectmodel',
+				'ui',
+				'userinterface',
+				'display',
+				'layout',
+				'design',
+				'landingpage',
+				'landingpagemode',
+				'default',
+				'chat',
+				'chatbubble',
+				'chatui',
+				'username',
+				'showusername',
+				'displayusername',
+				'widescreen',
+				'widescreenmode',
+				'fullscreen',
+				'expandmode',
+				'chatdirection',
+				'lefttoright',
+				'ltr',
+				'righttoleft',
+				'rtl',
+				'notifications',
+				'toast',
+				'toastnotifications',
+				'largechunks',
+				'streamlargechunks',
+				'scroll',
+				'scrollonbranchchange',
+				'scrollbehavior',
+				'richtext',
+				'richtextinput',
+				'background',
+				'chatbackground',
+				'chatbackgroundimage',
+				'backgroundimage',
+				'uploadbackground',
+				'resetbackground',
+				'titleautogen',
+				'titleautogeneration',
+				'autotitle',
+				'chattags',
+				'autochattags',
+				'responseautocopy',
+				'clipboard',
+				'location',
+				'userlocation',
+				'userlocationaccess',
+				'haptic',
+				'hapticfeedback',
+				'vibration',
+				'voice',
+				'voicecontrol',
+				'voiceinterruption',
+				'call',
+				'emojis',
+				'displayemoji',
+				'save',
+				'interfaceoptions',
+				'interfacecustomization',
+				'alwaysonwebsearch'
+			],
+			display: isAdminRole
+		},
+		{
+			id: 'connections',
+			title: 'Connections',
+			keywords: [],
+			display: isAdminRole
+		},
+		{
+			id: 'tools',
+			title: 'Tools',
+			keywords: [],
+			display: isAdminRole
+		},
+		{
+			id: 'personalization',
+			title: 'Personalization',
+			keywords: [
+				'personalization',
+				'memory',
+				'personalize',
+				'preferences',
+				'profile',
+				'personalsettings',
+				'customsettings',
+				'userpreferences',
+				'accountpreferences'
+			],
+			display: isAdminRole
+		},
 		// {
 		// 	id: 'audio',
 		// 	title: 'Audio',
@@ -193,78 +201,81 @@
 		// 		'voicemodes'
 		// 	]
 		// },
-		// {
-		// 	id: 'chats',
-		// 	title: 'Chats',
-		// 	keywords: [
-		// 		'chat',
-		// 		'messages',
-		// 		'conversations',
-		// 		'chatsettings',
-		// 		'history',
-		// 		'chathistory',
-		// 		'messagehistory',
-		// 		'messagearchive',
-		// 		'convo',
-		// 		'chats',
-		// 		'conversationhistory',
-		// 		'exportmessages',
-		// 		'chatactivity'
-		// 	]
-		// },
-		// {
-		// 	id: 'account',
-		// 	title: 'Account',
-		// 	keywords: [
-		// 		'account',
-		// 		'profile',
-		// 		'security',
-		// 		'privacy',
-		// 		'settings',
-		// 		'login',
-		// 		'useraccount',
-		// 		'userdata',
-		// 		'api',
-		// 		'apikey',
-		// 		'userprofile',
-		// 		'profiledetails',
-		// 		'accountsettings',
-		// 		'accountpreferences',
-		// 		'securitysettings',
-		// 		'privacysettings'
-		// 	]
-		// },
-		// {
-		// 	id: 'admin',
-		// 	title: 'Admin',
-		// 	keywords: [
-		// 		'admin',
-		// 		'administrator',
-		// 		'adminsettings',
-		// 		'adminpanel',
-		// 		'systemadmin',
-		// 		'administratoraccess',
-		// 		'systemcontrol',
-		// 		'manage',
-		// 		'management',
-		// 		'admincontrols',
-		// 		'adminfeatures',
-		// 		'usercontrol',
-		// 		'arenamodel',
-		// 		'evaluations',
-		// 		'websearch',
-		// 		'database',
-		// 		'pipelines',
-		// 		'images',
-		// 		'audio',
-		// 		'documents',
-		// 		'rag',
-		// 		'models',
-		// 		'ollama',
-		// 		'openai',
-		// 		'users'
-		// 	]
-		// },
+		{
+			id: 'chats',
+			title: 'Chats',
+			keywords: [
+				'chat',
+				'messages',
+				'conversations',
+				'chatsettings',
+				'history',
+				'chathistory',
+				'messagehistory',
+				'messagearchive',
+				'convo',
+				'chats',
+				'conversationhistory',
+				'exportmessages',
+				'chatactivity'
+			],
+			display: isAdminRole
+		},
+		{
+			id: 'account',
+			title: 'Account',
+			keywords: [
+				'account',
+				'profile',
+				'security',
+				'privacy',
+				'settings',
+				'login',
+				'useraccount',
+				'userdata',
+				'api',
+				'apikey',
+				'userprofile',
+				'profiledetails',
+				'accountsettings',
+				'accountpreferences',
+				'securitysettings',
+				'privacysettings'
+			],
+			display: isAdminRole
+		},
+		{
+			id: 'admin',
+			title: 'Admin',
+			keywords: [
+				'admin',
+				'administrator',
+				'adminsettings',
+				'adminpanel',
+				'systemadmin',
+				'administratoraccess',
+				'systemcontrol',
+				'manage',
+				'management',
+				'admincontrols',
+				'adminfeatures',
+				'usercontrol',
+				'arenamodel',
+				'evaluations',
+				'websearch',
+				'database',
+				'pipelines',
+				'images',
+				'audio',
+				'documents',
+				'rag',
+				'models',
+				'ollama',
+				'openai',
+				'users'
+			],
+			display: isAdminRole
+		},
 		{
 			id: 'about',
 			title: 'About',
@@ -290,13 +301,14 @@
 				// 'termsandconditions',
 				// 'contact',
 				// 'aboutpage'
-			]
+			],
+			display: true
 		}
 	];
 
 	let search = '';
-	let visibleTabs = searchData.map((tab) => tab.id);
-	let searchDebounceTimeout;
+	let visibleTabs = searchData.filter((tab) => tab.display).map((tab) => tab.id);
+	let searchDebounceTimeout: NodeJS.Timeout;
 
 	const searchSettings = (query: string): string[] => {
 		const lowerCaseQuery = query.toLowerCase().trim();

--- a/src/lib/components/layout/Navbar.svelte
+++ b/src/lib/components/layout/Navbar.svelte
@@ -116,7 +116,7 @@
 						</button>
 					</Menu>
 				{:else if $mobile}
-					<Tooltip content={$i18n.t('Controls')}>
+					<!-- <Tooltip content={$i18n.t('Controls')}>
 						<button
 							class=" flex cursor-pointer px-2 py-2 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-850 transition"
 							on:click={async () => {
@@ -128,10 +128,10 @@
 								<AdjustmentsHorizontal className=" size-5" strokeWidth="0.5" />
 							</div>
 						</button>
-					</Tooltip>
+					</Tooltip> -->
 				{/if}
 
-				{#if !$mobile}
+				<!-- {#if !$mobile}
 					<Tooltip content={$i18n.t('Controls')}>
 						<button
 							class=" flex cursor-pointer px-2 py-2 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-850 transition"
@@ -145,7 +145,7 @@
 							</div>
 						</button>
 					</Tooltip>
-				{/if}
+				{/if} -->
 
 				<Tooltip content={$i18n.t('New Chat')}>
 					<button

--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -202,7 +202,7 @@
 					class="flex gap-2 items-center px-3 py-2 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
 					id="chat-controls-button"
 					on:click={async () => {
-						await showControls.set(true);
+						// await showControls.set(true);
 						await showOverview.set(false);
 						await showArtifacts.set(false);
 					}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled the Controls button across desktop and mobile; tooltip and click behavior removed.
  * Mobile menu’s Controls option no longer opens the Controls panel; it only closes other panels.
  * Settings modal simplified: in-UI search removed; tabs are now selectively visible (General and About shown by default; others, including a new Audio tab, hidden by default).
  * Back navigation buttons removed from Artifacts and Overview headers; other header controls unchanged.
  * New Chat, model selector, and user menu unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->