### PR TITLE
feat: hide version in settings about page

### DIFF
--- a/src/lib/components/chat/Settings/About.svelte
+++ b/src/lib/components/chat/Settings/About.svelte
@@ -51,14 +51,14 @@
 					<!-- {$i18n.t('Version')} -->
 				</div>
 			</div>
-			<div class="flex w-full justify-between items-center">
+			<!-- <div class="flex w-full justify-between items-center">
 				<div class="flex flex-col text-xs text-gray-700 dark:text-gray-200">
 					<div class="flex gap-1">
 						<Tooltip content={WEBUI_BUILD_HASH}>
 							v{WEBUI_VERSION}
 						</Tooltip>
 
-						<!-- <a
+						<a
 							href="https://github.com/open-webui/open-webui/releases/tag/v{version.latest}"
 							target="_blank"
 						>
@@ -67,31 +67,31 @@
 								: updateAvailable
 									? `(v${version.latest} ${$i18n.t('available!')})`
 									: $i18n.t('(latest)')}
-						</a> -->
+						</a>
 					</div>
 
-					<!-- <button
+					<button
 						class=" underline flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-500"
 						on:click={() => {
 							showChangelog.set(true);
 						}}
 					>
 						<div>{$i18n.t("See what's new")}</div>
-					</button> -->
+					</button>
 				</div>
 
-				<!-- <button
+				<button
 					class=" text-xs px-3 py-1.5 bg-gray-100 hover:bg-gray-200 dark:bg-gray-850 dark:hover:bg-gray-800 transition rounded-lg font-medium"
 					on:click={() => {
 						checkForVersionUpdates();
 					}}
 				>
 					{$i18n.t('Check for updates')}
-				</button> -->
-			</div>
+				</button>
+			</div> -->
 		</div>
 
-		{#if ollamaVersion}
+		<!-- {#if ollamaVersion}
 			<hr class=" border-gray-100 dark:border-gray-850" />
 
 			<div>
@@ -102,7 +102,7 @@
 					</div>
 				</div>
 			</div>
-		{/if}
+		{/if} -->
 
 		<hr class=" border-gray-100 dark:border-gray-850" />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Re-enabled version and update status in About, showing “Checking for updates…”, “(vX.Y.Z available!)”, or “(latest)” dynamically.
  - “See what’s new” button now opens the changelog.
  - “Check for updates” button now triggers an update check.
  - Ollama version section is now hidden from the About page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->