### PR TITLE
(WIP) feat: fix google analytics chat title

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1927,11 +1927,12 @@
 </script>
 
 <svelte:head>
-	<title>
+	<!-- <title>
 		{$chatTitle
 			? `${$chatTitle.length > 30 ? `${$chatTitle.slice(0, 30)}...` : $chatTitle} | ${$WEBUI_NAME}`
 			: `${$WEBUI_NAME}`}
-	</title>
+	</title> -->
+	<title>{$WEBUI_NAME}</title>
 </svelte:head>
 
 <audio id="audioElement" src="" style="display: none;" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized the browser tab title in the chat view to always display the app name for consistent branding.
  - Removed dynamic chat-based titles and truncation from the tab, reducing variability across sessions and improving recognition.
  - No changes to chat functionality or workflows; this update only affects the displayed page title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->