### PR TITLE
fix: track web search enabled status for user

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -461,7 +461,6 @@
 		chatIdUnsubscriber?.();
 		window.removeEventListener('message', onMessageHandler);
 		$socket?.off('chat-events', chatEventHandler);
-		localStorage.setItem(WEB_SEARCH_STORAGE_KEY, webSearchEnabled ? 'true' : 'false');
 	});
 
 	// File upload functions

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -90,7 +90,7 @@
 	import Spinner from '../common/Spinner.svelte';
 	import ChatVerifier from './ChatVerifier.svelte';
 
-	const WEB_SEARCH_STATUS_KEY = 'web-search-status';
+	const WEB_SEARCH_STATUS_KEY = 'web-search-enabled-status';
 
 	export let chatIdProp = '';
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -90,6 +90,8 @@
 	import Spinner from '../common/Spinner.svelte';
 	import ChatVerifier from './ChatVerifier.svelte';
 
+	const WEB_SEARCH_STATUS_KEY = 'web-search-status';
+
 	export let chatIdProp = '';
 
 	let loading = false;
@@ -124,7 +126,7 @@
 
 	let selectedToolIds = [];
 	let imageGenerationEnabled = false;
-	let webSearchEnabled = false;
+	let webSearchEnabled = sessionStorage.getItem(WEB_SEARCH_STATUS_KEY) === 'true';
 	let codeInterpreterEnabled = false;
 
 	let chat = null;
@@ -142,6 +144,14 @@
 	let chatFiles = [];
 	let files = [];
 	let params = {};
+
+	$: {
+		if (webSearchEnabled) {
+			sessionStorage.setItem(WEB_SEARCH_STATUS_KEY, 'true');
+		} else {
+			sessionStorage.removeItem(WEB_SEARCH_STATUS_KEY);
+		}
+	}
 
 	$: if (chatIdProp) {
 		(async () => {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -151,7 +151,6 @@
 			prompt = '';
 			files = [];
 			selectedToolIds = [];
-			webSearchEnabled = false;
 			imageGenerationEnabled = false;
 
 			if (chatIdProp && (await loadChat())) {
@@ -165,7 +164,6 @@
 						prompt = input.prompt;
 						files = input.files;
 						selectedToolIds = input.selectedToolIds;
-						webSearchEnabled = input.webSearchEnabled;
 						imageGenerationEnabled = input.imageGenerationEnabled;
 					} catch (e) {}
 				}
@@ -424,13 +422,11 @@
 				prompt = input.prompt;
 				files = input.files;
 				selectedToolIds = input.selectedToolIds;
-				webSearchEnabled = input.webSearchEnabled;
 				imageGenerationEnabled = input.imageGenerationEnabled;
 			} catch (e) {
 				prompt = '';
 				files = [];
 				selectedToolIds = [];
-				webSearchEnabled = false;
 				imageGenerationEnabled = false;
 			}
 		}
@@ -465,6 +461,7 @@
 		chatIdUnsubscriber?.();
 		window.removeEventListener('message', onMessageHandler);
 		$socket?.off('chat-events', chatEventHandler);
+		localStorage.setItem(WEB_SEARCH_STORAGE_KEY, webSearchEnabled ? 'true' : 'false');
 	});
 
 	// File upload functions

--- a/src/lib/components/chat/ChatVerifier.svelte
+++ b/src/lib/components/chat/ChatVerifier.svelte
@@ -78,7 +78,7 @@
 				<div class="flex-shrink-0 dark:border-gray-700">
 					<div class="p-4">
 						<h2
-							class="text-base font-semibold text-gray-900 flex rounded items-center pl-4 dark:text-gray-300 h-8 mb-3"
+							class="text-base font-semibold text-gray-900 flex rounded items-center dark:text-gray-300 h-8 mb-3"
 						>
 							Model Verification
 						</h2>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Web search setting is now session-scoped and persists across reloads; per-chat persistence and per-chat resets were removed, and the setting is no longer auto-reset on chat errors.

- Style
  - Reduced left padding on the Model Verification header, causing a slight alignment shift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->