### PR TITLE
fix: clear chat verifier's state when changing chat

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1960,6 +1960,7 @@
 <ChatVerifier
 	{history}
 	token={localStorage.token}
+	chatId={$chatId}
 	{selectedModels}
 	bind:expanded={showChatVerifier}
 	on:toggle={(e) => {

--- a/src/lib/components/chat/ChatVerifier.svelte
+++ b/src/lib/components/chat/ChatVerifier.svelte
@@ -8,6 +8,7 @@
 		messages: Record<string, Message>;
 		currentId: string | null;
 	};
+	export let chatId = null;
 	export let token: string;
 	export let selectedModels: string[];
 	export let expanded = false;
@@ -200,7 +201,7 @@
 							</h2>
 						</div>
 						<div class="flex-1 overflow-y-auto">
-							<MessagesVerifier {history} {token} />
+							<MessagesVerifier {history} {token} {chatId} />
 						</div>
 					</div>
 				</div>

--- a/src/lib/components/chat/MessagesVerifier.svelte
+++ b/src/lib/components/chat/MessagesVerifier.svelte
@@ -9,6 +9,7 @@
 		currentId: string | null;
 	};
 	export let token: string;
+	export let chatId = null;
 
 	let signatures: Record<string, MessageSignature> = {};
 	let loadingSignatures: Set<string> = new Set();
@@ -139,6 +140,11 @@
 		showVerifySignatureDialog = false;
 		selectedSignature = null;
 	};
+
+	$: {
+		chatId;
+		selectedMessageId = '';
+	}
 </script>
 
 <div class="space-y-4 h-full overflow-y-auto pb-4 px-4" bind:this={containerElement}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat and verification components now track the active conversation, improving context awareness.
  * When switching between chats, any selected message is automatically cleared to prevent carryover between conversations.
  * Enhanced compatibility across chat-related components by propagating the active chat context end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->