### PR TITLE
fix: error when editing settings

### DIFF
--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -93,6 +93,7 @@
 	};
 
 	const saveHandler = async () => {
+		requestFormat = requestFormat === 'null' ? null : requestFormat;
 		if (requestFormat !== null && requestFormat !== 'json') {
 			if (validateJSON(requestFormat) === false) {
 				toast.error($i18n.t('Invalid JSON schema'));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * General settings now correctly handle an unset request format. Selecting “None” no longer saves or displays the literal "null" string; it’s treated as unset, improving validation and persistence.
  * Prevents incorrect “null” values from appearing in the UI and avoids related save errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->