### PR TITLE
feat: remove reasoning tags in chat verification message display

### DIFF
--- a/src/lib/components/chat/MessagesVerifier.svelte
+++ b/src/lib/components/chat/MessagesVerifier.svelte
@@ -3,6 +3,7 @@
 	import VerifySignatureDialog from './VerifySignatureDialog.svelte';
 	import type { Message } from '$lib/types';
 	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
+	import { stripHtmlTags } from '$lib/utils/html';
 
 	export let history: {
 		messages: Record<string, Message>;
@@ -192,7 +193,7 @@
 								? 'dark:text-white!'
 								: ''}"
 						>
-							{message.content}
+							{stripHtmlTags(message.content)}
 						</p>
 						<p class="text-xs text-gray-500 dark:text-rgba(248,248,248,0.64)">
 							ID: {message.chatCompletionId}

--- a/src/lib/utils/html.ts
+++ b/src/lib/utils/html.ts
@@ -1,0 +1,26 @@
+export function stripHtmlTags(html: string | null | undefined): string {
+	try {
+		if (!html || typeof html !== 'string') return '';
+
+		let text = html.replace(/<[^>]*>?/gm, '');
+		const htmlEntities: Record<string, string> = {
+			'&amp;': '&',
+			'&lt;': '<',
+			'&gt;': '>',
+			'&quot;': '"',
+			'&#39;': "'",
+			'&#039;': "'",
+			'&nbsp;': ' ',
+			'&#160;': ' '
+		};
+
+		text = text.replace(
+			new RegExp(Object.keys(htmlEntities).join('|'), 'g'),
+			(match) => htmlEntities[match] || match
+		);
+		return text.trim().replace(/\s+/g, ' ');
+	} catch (err) {
+		console.error('Error stripping HTML tags:', err);
+		return html || '';
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Verifiable Messages now render content as plain text, stripping HTML tags to prevent unintended formatting and improve readability.
  - Common HTML entities are decoded and excessive whitespace is collapsed for cleaner display.

- Refactor
  - Introduced a text normalization utility to standardize how message content is processed and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->