### PR TITLE
feat: disable some features: capture, edit assistant response, save edited user message, external icon

### DIFF
--- a/src/lib/components/chat/MessageInput/InputMenu.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu.svelte
@@ -145,7 +145,7 @@
 				<hr class="border-black/5 dark:border-white/5 my-1" />
 			{/if}
 
-			<Tooltip
+			<!-- <Tooltip
 				content={!fileUploadEnabled ? $i18n.t('You do not have permission to upload files') : ''}
 				className="w-full"
 			>
@@ -170,7 +170,7 @@
 					<CameraSolid />
 					<div class=" line-clamp-1">{$i18n.t('Capture')}</div>
 				</DropdownMenu.Item>
-			</Tooltip>
+			</Tooltip> -->
 
 			<Tooltip
 				content={!fileUploadEnabled ? $i18n.t('You do not have permission to upload files') : ''}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -974,7 +974,7 @@
 							{/if}
 
 							{#if message.done}
-								{#if !readOnly}
+								<!-- {#if !readOnly}
 									{#if $user?.role === 'user' ? ($user?.permissions?.chat?.edit ?? true) : true}
 										<Tooltip content={$i18n.t('Edit')} placement="bottom">
 											<button
@@ -1002,7 +1002,7 @@
 											</button>
 										</Tooltip>
 									{/if}
-								{/if}
+								{/if} -->
 
 								<Tooltip content={$i18n.t('Copy')} placement="bottom">
 									<button

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -190,7 +190,7 @@
 
 						<div class=" mt-2 mb-1 flex justify-between text-sm font-medium">
 							<div>
-								<button
+								<!-- <button
 									id="save-edit-message-button"
 									class=" px-4 py-2 bg-gray-50 hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 border border-gray-100 dark:border-gray-700 text-gray-700 dark:text-gray-200 transition rounded-3xl"
 									on:click={() => {
@@ -198,7 +198,7 @@
 									}}
 								>
 									{$i18n.t('Save')}
-								</button>
+								</button> -->
 							</div>
 
 							<div class="flex space-x-1.5">

--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -564,7 +564,7 @@
 											</svg>
 										</div>
 									</Tooltip>
-								{:else if item.model.owned_by === 'openai'}
+									<!-- {:else if item.model.owned_by === 'openai'}
 									<Tooltip content={`${'External'}`}>
 										<div class="translate-y-[1px]">
 											<svg
@@ -585,7 +585,7 @@
 												/>
 											</svg>
 										</div>
-									</Tooltip>
+									</Tooltip> -->
 								{/if}
 
 								{#if item.model?.info?.meta?.description}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Upload Files” option in the message input menu (when file uploads are enabled).

- UI Changes
  - Removed camera capture option from the message input menu.
  - Disabled the “Edit” action on assistant responses.
  - Removed the “Save” button from user message editing; “Cancel” and “Send” remain.
  - Hid the “OpenAI-owned” external indicator in the model selector.
  - Google Drive and OneDrive options are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->