### PR TITLE
feat: lazy loading for message signature

### DIFF
--- a/src/lib/components/chat/MessagesVerifier.svelte
+++ b/src/lib/components/chat/MessagesVerifier.svelte
@@ -71,15 +71,6 @@
 		}
 	};
 
-	// Function to verify all message signatures
-	const verifyAllMessageSignatures = async () => {
-		for (const message of chatCompletions) {
-			if (message.chatCompletionId && !signatures[message.chatCompletionId]) {
-				await fetchMessageSignature(message.model, message.chatCompletionId);
-			}
-		}
-	};
-
 	// Function to scroll to selected message
 	const scrollToSelectedMessage = () => {
 		if (!containerElement || !selectedMessageId) return;
@@ -120,15 +111,6 @@
 		}, 300); // Increased delay to ensure DOM is updated
 	};
 
-	// Auto-fetch signatures when chatCompletions change
-	$: if (history && token && chatCompletions.length > 0) {
-		chatCompletions.forEach((message: Message) => {
-			if (message.chatCompletionId && !signatures[message.chatCompletionId]) {
-				fetchMessageSignature(message.model, message.chatCompletionId);
-			}
-		});
-	}
-
 	const openVerifySignatureDialog = () => {
 		if (!signatures[selectedMessageId]) return;
 		if (!signatures[selectedMessageId].signature) return;
@@ -145,6 +127,22 @@
 		chatId;
 		selectedMessageId = '';
 	}
+
+	$: if (selectedMessageId && history && token && chatCompletions.length > 0) {
+		const msg = chatCompletions.find((message) => message.chatCompletionId === selectedMessageId);
+		if (msg && msg.chatCompletionId && !signatures[msg.chatCompletionId]) {
+			fetchMessageSignature(msg.model, msg.chatCompletionId);
+		}
+	}
+
+	// Auto-fetch signatures when chatCompletions change
+	// $: if (history && token && chatCompletions.length > 0) {
+	// 	chatCompletions.forEach((message: Message) => {
+	// 		if (message.chatCompletionId && !signatures[message.chatCompletionId]) {
+	// 			fetchMessageSignature(message.model, message.chatCompletionId);
+	// 		}
+	// 	});
+	// }
 </script>
 
 <div class="space-y-4 h-full overflow-y-auto pb-4 px-4" bind:this={containerElement}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Switched message signature verification to on-demand for the currently selected message, reducing background requests and improving responsiveness.
  * Removed automatic bulk verification to streamline loading.
  * No changes to public APIs.

* **Bug Fixes**
  * Selected message now resets when switching chats to prevent mismatches and ensure correct verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->