### PR TITLE
fix: hide "New Folder" button

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -656,9 +656,6 @@
 				collapsible={!search}
 				className="px-2 mt-0.5"
 				name={$i18n.t('Chats')}
-				onAdd={() => {
-					createFolder();
-				}}
 				onAddLabel={$i18n.t('New Folder')}
 				on:import={(e) => {
 					importChatHandler(e.detail);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled automatic creation of new chat folders from the sidebar, preventing unintended folder additions.
  * The “Add” action for the Chats folder is no longer available; folder creation now occurs only through existing label, import, or drag-and-drop actions.

* **Refactor**
  * Streamlined sidebar folder interactions with no changes to labeling, import, or drag-and-drop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->