### PR TITLE
feat:  preserve user-entered question after login from the welcome page

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -416,6 +416,7 @@
 		console.log('mounted');
 		window.addEventListener('message', onMessageHandler);
 		$socket?.on('chat-events', chatEventHandler);
+		const welcomePrompt = sessionStorage.getItem('welcome-prompt');
 
 		if (!$chatId) {
 			chatIdUnsubscriber = chatId.subscribe(async (value) => {
@@ -442,6 +443,11 @@
 				files = [];
 				selectedToolIds = [];
 				imageGenerationEnabled = false;
+			}
+		} else {
+			if (welcomePrompt) {
+				prompt = welcomePrompt;
+				sessionStorage.removeItem('welcome-prompt');
 			}
 		}
 

--- a/src/routes/welcome/+page.svelte
+++ b/src/routes/welcome/+page.svelte
@@ -44,6 +44,7 @@
 	$: getFilteredPrompts(inputValue);
 
 	const gotoAuth = async () => {
+		sessionStorage.setItem('welcome-prompt', inputValue);
 		await goto(`/auth`);
 	};
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Your welcome prompt is now preserved through sign-in and automatically prefilled when you return to an existing chat, reducing retyping.
* **Improvements**
  * Smoother welcome flow: prompts entered before authentication are carried over and applied when resuming a chat.
  * After being used once, the prefilled prompt won’t reappear unexpectedly.
  * Behavior applies when resuming existing chats; starting a brand-new chat remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->