### PR TITLE
fix: modify KaTeX matching $$$ in markdown renderer

### DIFF
--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -116,7 +116,7 @@ function katexStart(src, displayMode: boolean) {
 function katexTokenizer(src, tokens, displayMode: boolean) {
 	let ruleReg = displayMode ? blockRule : inlineRule;
 	let type = displayMode ? 'blockKatex' : 'inlineKatex';
-	if (src === '$$$') return;
+	if (src.startsWith('$$$')) return;
 
 	const match = src.match(ruleReg);
 

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -116,6 +116,7 @@ function katexStart(src, displayMode: boolean) {
 function katexTokenizer(src, tokens, displayMode: boolean) {
 	let ruleReg = displayMode ? blockRule : inlineRule;
 	let type = displayMode ? 'blockKatex' : 'inlineKatex';
+	if (src === '$$$') return;
 
 	const match = src.match(ruleReg);
 

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -80,6 +80,15 @@ function katexStart(src, displayMode: boolean) {
 				continue;
 			}
 
+			const prevChar = startIndex > 0 ? indexSrc.charAt(startIndex - 1) : '';
+			const nextChar = indexSrc.charAt(startIndex + delimiter.left.length);
+			if (delimiter.left === '$' && (prevChar === '$' || nextChar === '$')) {
+				continue;
+			}
+			if (delimiter.left === '$$' && (prevChar === '$' || nextChar === '$')) {
+				continue;
+			}
+
 			index = startIndex;
 			startDelimiter = delimiter.left;
 			endDelimiter = delimiter.right;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents single "$" and double "$$" math delimiters from being misinterpreted when adjacent to other dollar signs.
  * Stops triple-dollar sequences (e.g., "$$$") from being treated as math delimiters.
  * Improves Markdown math rendering reliability, reducing broken equations and unexpected formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->