### PR TITLE
fix: remove crisp chat cookies

### DIFF
--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -95,6 +95,11 @@ export function setupVirtualGaCookies() {
 
 				virtualGaCookiesObj[cookieName] = cookieValue;
 				return value;
+			} else if (
+				// Don't save PostHog cookies used by Crisp Chat
+				value.startsWith('ph_phc_')
+			) {
+				return value;
 			}
 			// Handle other cookies
 			return cookieDesc?.set?.call(document, value);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded PostHog/Crisp Chat cookies from analytics cookie handling to prevent misclassification and noise in metrics.
  * Preserved existing behavior for Google Analytics cookies, ensuring accurate reporting remains unchanged.
  * Reduced unnecessary cookie storage and minimized potential conflicts with chat functionality.
  * Improves overall analytics data quality without impacting user-facing UI or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->