### PR TITLE
fix: do not cache root path

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -370,7 +370,7 @@ class SPAStaticFiles(StaticFiles):
                 }
                 if not path.endswith(".html"):
                     custom_headers["Cache-Control"] = (
-                        "public, max-age=31536000, immutable"
+                        "public, max-age=86400"
                     )
 
                 if "gzip" in accept_encoding:

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -383,15 +383,7 @@ class SPAStaticFiles(StaticFiles):
             pass
 
         try:
-            if path.endswith(".html"):
-                return await super().get_response(path, scope)
-            else:
-                response = await super().get_response(path, scope)
-                if hasattr(response, "headers"):
-                    response.headers["Cache-Control"] = (
-                        "public, max-age=31536000, immutable"
-                    )
-                return response
+            return await super().get_response(path, scope)
         except (HTTPException, StarletteHTTPException) as ex:
             if ex.status_code == 404:
                 if path.endswith(".js"):

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -369,9 +369,7 @@ class SPAStaticFiles(StaticFiles):
                     "Vary": "Accept-Encoding",
                 }
                 if not path.endswith(".html"):
-                    custom_headers["Cache-Control"] = (
-                        "public, max-age=86400"
-                    )
+                    custom_headers["Cache-Control"] = "public, max-age=86400"
 
                 if "gzip" in accept_encoding:
                     return FileResponse(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated asset-serving behavior to a single, consistent pathway for all file types, removing previous special-case handling.
  * Standardized Cache-Control for non-HTML assets to a shorter, uniform lifetime (reduced to 24 hours), replacing the prior long-term caching approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->